### PR TITLE
fix: harden Group A correctness paths (race/idempotency/resource caps)

### DIFF
--- a/api/routers/automation.py
+++ b/api/routers/automation.py
@@ -10,7 +10,7 @@ from api.utils.files import (
     to_wine_path,
     read_session_dir,
 )
-from api.utils.process import safe_command, manage_process
+from api.utils.process import safe_command, manage_process, ProcessCapacityError
 from api.core.models import (
     AppRunModel,
     InspectWindowModel,
@@ -85,7 +85,10 @@ async def run_app(data: AppRunModel):
 
     if data.detach:
         proc = subprocess.Popen(cmd, start_new_session=True)
-        manage_process(proc)
+        try:
+            manage_process(proc)
+        except ProcessCapacityError as exc:
+            raise HTTPException(status_code=503, detail=str(exc))
         session_dir = read_session_dir()
         emit_operation_timing(
             session_dir,

--- a/api/routers/recording.py
+++ b/api/routers/recording.py
@@ -29,7 +29,7 @@ from api.utils.files import (
     read_pid,
     performance_metrics_log_path,
 )
-from api.utils.process import manage_process, run_async_command
+from api.utils.process import manage_process, run_async_command, ProcessCapacityError
 
 router = APIRouter(prefix="/recording", tags=["recording"])
 
@@ -150,7 +150,10 @@ async def start_recording(data: Optional[RecordingStartModel] = Body(default=Non
             str(segment),
         ]
         proc = subprocess.Popen(cmd)
-        manage_process(proc)
+        try:
+            manage_process(proc)
+        except ProcessCapacityError as exc:
+            raise HTTPException(status_code=503, detail=str(exc))
 
         pid = None
         pid_file = os.path.join(session_dir, "recorder.pid")

--- a/api/server.py
+++ b/api/server.py
@@ -24,7 +24,7 @@ from api.utils.files import (
     link_wine_user_dir,
     write_instance_state,
 )
-from api.utils.process import process_store
+from api.utils.process import reap_finished_tracked_processes
 from api.core.discovery import discovery_manager
 from api.core.versioning import (
     API_VERSION,
@@ -60,10 +60,8 @@ async def resource_monitor_task():
     cleanup_counter = 0
     logger.info("Resource monitor task started.")
     while True:
-        # Reap zombie processes
-        for proc in list(process_store):
-            if proc.poll() is not None:
-                process_store.discard(proc)
+        # Reap completed detached children under lock.
+        reap_finished_tracked_processes()
 
         # Periodic session cleanup (every 60 seconds)
         cleanup_counter += 5


### PR DESCRIPTION
## Summary
- harden detached process tracking with explicit capacity errors and locked reaping
- prevent silent process tracking overflow by surfacing 503 responses on capacity exhaustion
- make broker state handling atomic and return snapshot state copies to callers
- add lifecycle shutdown idempotency guard and remove duplicate shutdown signal path
- add regression tests for process-capacity behavior and shutdown idempotency

## Validation
- ./scripts/wb lint
- ./scripts/wb test --unit-only
  - unit: 75 passed
  - e2e: 12 passed

## Deferred follow-ups
- Group B (write-failure surfacing + atomic log caps): #25
- Group C (mypy untyped-body checks for discovery): #26