### PR TITLE
docs: sync CLI features and agent documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ WineBot is a containerized Windows application runtime (Wine 10.0) with an X11 d
 | `docker/entrypoint.sh` | Container boot logic. Handles Xvfb, Openbox, Wine init. | `Xvfb`, `wineserver`, `tint2` |
 | `docker/openbox/rc.xml` | Window Manager config. Controls input focus/decorations. | `<applications>`, `<mouse>` |
 | `scripts/bin/` | Primary user-facing tools (`winebotctl`, `run-app.sh`). | |
-| `scripts/diagnostics/` | System validation suite (`diagnose-master.sh`, `health-check.sh`). | `Environment Health` |
+| `scripts/diagnostics/` | System validation suite (`diagnose-master.sh`, `health-check.sh`). | `diagnose-master.sh` |
 | `scripts/setup/` | Installation and fix logic (`install-theme.sh`, `fix-wine-input.sh`). | |
 | `automation/bin/` | Standalone automation tools (`x11.sh`, `screenshot.sh`). | |
 | `automation/examples/` | Demo and verification scripts (`notepad_create_and_verify.py`). | |
@@ -68,6 +68,12 @@ scripts/winebotctl config set KEY VALUE
 
 # 2. Apply (Restarts container)
 scripts/winebotctl config apply
+```
+
+### How to trace input?
+```bash
+scripts/winebotctl input trace start --layer windows
+scripts/winebotctl input trace events --source client --limit 50
 ```
 
 ### How to debug input issues?

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Use this for project maintenance and verification:
 - `./scripts/wb test`: Run unit and E2E tests.
 - `./scripts/wb build [intent]`: Build local images (e.g., `slim`, `dev`, `rel`).
 - `./scripts/wb vuln`: Run vulnerability scans.
+- `./scripts/wb ctl`: Alias for scripts/winebotctl.
 
 ### 2. Operator Tool (`scripts/winebotctl`)
 Use this to automate applications:
@@ -27,6 +28,8 @@ Use this to automate applications:
 - `scripts/winebotctl screenshot`: Capture the virtual desktop.
 - `scripts/winebotctl apps run "/path/to/app.exe"`: Launch a Windows app.
 - `scripts/winebotctl input click 100 200`: Perform a mouse click.
+- `scripts/winebotctl lifecycle shutdown --yes`: Shutdown the instance.
+- `scripts/winebotctl config profile set human-desktop`: Set a profile.
 
 ## Configuration
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -32,6 +32,10 @@ Examples:
 - `scripts/winebotctl sessions list`
 - `scripts/winebotctl recording start --session-root /artifacts/sessions`
 - `scripts/winebotctl api POST /sessions/suspend --json '{"shutdown_wine":true}'`
+- `scripts/winebotctl tail`
+- `scripts/winebotctl config profile set human-desktop`
+- `scripts/winebotctl lifecycle shutdown --yes`
+- `scripts/winebotctl input trace start --layer windows`
 
 Idempotent mode is supported (see `--idempotent` / `--no-idempotent`) so repeat invocations can safely reuse the same response when desired.
 


### PR DESCRIPTION
This PR updates the documentation across `README.md` (user-facing), `docs/api.md` (API-facing), and `AGENTS.md` (agent-facing) to ensure that the examples and CLI usage instructions reflect the current state of the `winebotctl` and `wb` tools. New command additions include `winebotctl config profile set`, `lifecycle shutdown`, `input trace`, and log `tail`.

---
*PR created automatically by Jules for task [13878570105089540832](https://jules.google.com/task/13878570105089540832) started by @mark-e-deyoung*