### PR TITLE
docs: document input pipeline architecture and headless keyboard barrier

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -22,6 +22,65 @@ Install core fonts:
 
 Ensure `openbox` is running and the app is visible on the virtual desktop.
 
+## VNC/xdotool keyboard events don't reach the application
+
+**Symptom:** VNC key presses or `xdotool key` commands execute but don't affect the
+Windows application. `/proc/PID/mem` reads show no state changes. The app appears
+frozen or unresponsive to injected input.
+
+**Root cause:** Wine's `explorer.exe /desktop` creates a virtual Windows desktop
+as an X11 window. All VNC/xdotool keyboard events go to this desktop window, not
+to individual app windows within it. This is identical to how a real Windows
+desktop works — typing on the desktop background doesn't reach the foreground
+application.
+
+**Input pipeline:**
+```
+VNC Client → x11vnc(:5900) → Xvfb(:99) → explorer.exe /desktop → app.exe
+                                                    ^
+                                           KEYBOARD EVENTS STOP HERE
+```
+
+**Confirmed:** The `explorer.exe /desktop` process (visible via `pgrep -f "explorer.exe /desktop"`)
+intercepts all X11 keyboard input. A container supervisor continuously restarts
+it if killed, making standalone app windows impossible in the default configuration.
+
+**Solutions (in order of preference):**
+
+1. **Enable hybrid control mode** (recommended for API users):
+   ```bash
+   WINEBOT_ALLOW_HEADLESS_HYBRID=1
+   WINEBOT_INSTANCE_CONTROL_MODE=hybrid
+   ```
+   This enables `/apps/run`, `/run/ahk`, and `/run/python` endpoints that use
+   Windows hooks (AutoHotkey/Windows messages) for keyboard injection — these
+   bypass the X11 interception layer entirely.
+
+2. **Disable the desktop supervisor** (for xdotool/VNC keyboard users):
+   ```bash
+   WINEBOT_SUPERVISE_EXPLORER=0
+   ```
+   Then kill the desktop: `pkill -f "explorer.exe"`
+   Apps will create standalone X11 windows targetable by xdotool/VNC.
+
+3. **Use mouse-only VNC interaction** (workaround):
+   Mouse click events do reach the desktop and are forwarded to the app.
+   Use VNC framebuffer reads to visually locate UI elements, then click.
+   Keyboard shortcuts (Ctrl+L, Escape) can be simulated via on-screen
+   keyboard or menu navigation with mouse clicks.
+
+## Agent control denied by policy (HTTP 423)
+
+**Symptom:** API endpoints `/apps/run`, `/run/ahk`, `/run/python`, `/input/*`
+return `HTTP 423: Agent control denied by policy`.
+
+**Root cause:** The container is in `agent-only` control mode (default for headless).
+This mode blocks all agent-initiated app launches and code execution for safety.
+
+**Fix:** Set `WINEBOT_ALLOW_HEADLESS_HYBRID=1` and
+`WINEBOT_INSTANCE_CONTROL_MODE=hybrid` in the docker-compose environment.
+Then call `POST /control/mode {"mode": "hybrid"}` or restart the container.
+
 ## CV matching fails
 
 Enforce a fixed resolution and avoid UI scaling. Always use the same `SCREEN` value.


### PR DESCRIPTION
## Problem

Headless WineBot containers cannot inject keyboard input into Windows applications via VNC or xdotool. Key events arrive at Xvfb but never reach the target app. This was a long-running issue with the project.

## Root Cause (Definitive)

The Wine desktop shell (`explorer.exe /desktop`) intercepts ALL X11 keyboard input. The container runs a supervisor that continuously restarts this desktop, making it impossible to run apps in standalone X11 window mode.

**Input pipeline:**
```
VNC Client → x11vnc(:5900) → Xvfb(:99) → explorer.exe /desktop → terran.exe
                                                    ^
                                           KEYBOARD EVENTS STOP HERE
```

**Proof:** 
1. VNC RFB protocol handshake succeeds (DES auth, framebuffer reads confirm app rendering)
2. VNC key events (`struct.pack(">BBHI", 4, 1, 0, keysym)`) are acknowledged by x11vnc
3. `/proc/PID/mem` reads of the target app show NO state changes after key injection
4. Killing `explorer.exe /desktop` makes xdotool key injection work immediately
5. The supervisor restarts the desktop within seconds, re-blocking input

## Documentation Added

- **Input pipeline architecture** explaining the Xvfb → desktop → app chain
- **Three documented solutions** with tradeoffs (hybrid mode, no-desktop, mouse-only)
- **HTTP 423 troubleshooting** with root cause and fix

## Testing

No code changes — documentation only. Existing test suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>