### PR TITLE
Fix annotation server errors and document Git Bash path mangling

### DIFF
--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -205,3 +205,73 @@ scripts/run-app.sh "/wineprefix/drive_c/Program Files/MyApp/MyApp.exe" \
   --view vnc \
   --vnc-password "winebot"
 ```
+
+---
+
+## Git Bash Path Translation (Windows Host)
+
+When running `docker` commands from **Git Bash** (MSYS2/MinGW) on Windows, Unix-style
+paths like `/scripts` or `/tmp` are automatically translated to Windows paths:
+`C:/Program Files/Git/scripts` or `C:/Users/Mark/AppData/Local/Temp/`.
+
+This causes cryptic failures:
+```
+python3: can't open file '/work/C:/Program Files/Git/scripts/file.py': No such file or directory
+```
+
+### Prevention
+
+Prefix all `docker` commands with `MSYS_NO_PATHCONV=1` to disable path translation:
+
+```bash
+# WRONG — path gets mangled
+docker exec mycontainer python3 /scripts/annotation_server.py
+
+# RIGHT — path preserved
+MSYS_NO_PATHCONV=1 docker exec mycontainer python3 /scripts/annotation_server.py
+```
+
+### Affected Commands
+
+| Command | Without MSYS_NO_PATHCONV | With MSYS_NO_PATHCONV |
+|:---|:---|:---|
+| `docker exec ... python3 /path/to/script.py` | ❌ `File not found` | ✅ Works |
+| `docker cp /tmp/file container:/path/` | ❌ Wrong source path | ✅ Works |
+| `docker run -v C:\path:/container` | ❌ Wrong mount path | ✅ Use `//c/path` |
+| `docker exec -d ...` | ❌ Detached mode fails silently | ✅ Use MSYS_NO_PATHCONV |
+| `sh -c 'cat /tmp/file'` | ❌ `/tmp` → Windows temp | ✅ Works |
+
+### Docker Volume Mounts
+
+For volume mounts, use double-slash prefix for Windows paths:
+
+```bash
+# WRONG — Git Bash translates C:\path to /c/path with wrong format
+docker run -v C:\Users\me\data:/data ...
+
+# RIGHT — double-slash prevents translation
+docker run -v //c/Users/me/projects/models:/models ...
+```
+
+### Annotation Server (Specific Case)
+
+The annotation server requires this fix when started from the host:
+
+```bash
+# From the repo root:
+MSYS_NO_PATHCONV=1 docker exec -d winebot-cv python3 /scripts/annotation_server.py \
+  --dir /artifacts/annotations/images --port 8080 --sidecar http://localhost:8001
+
+# Or use the helper script:
+MSYS_NO_PATHCONV=1 bash scripts/start-annotation.sh
+```
+
+### Diagnostic
+
+If a command fails with path-related errors, check whether Git Bash is translating:
+
+```bash
+# Check if translation is happening
+docker exec winebot-cv python3 -c "import sys; print(sys.argv)" /scripts/test.py
+# If output shows C:/Program Files/Git/, MSYS_NO_PATHCONV=1 is needed.
+```

--- a/scripts/annotation_server.py
+++ b/scripts/annotation_server.py
@@ -22,7 +22,7 @@ Keyboard shortcuts:
   + / -       Zoom in/out
   Space       Auto-detect (if sidecar configured)
 """
-import argparse, base64, glob, io, json, os, sys, time
+import argparse, base64, glob, io, json, logging, os, socket, sys, time
 from pathlib import Path
 from typing import List, Optional
 
@@ -869,46 +869,91 @@ def main():
     parser.add_argument("--dir", "-d", default=".",
                         help="Directory containing images to annotate")
     parser.add_argument("--port", "-p", type=int, default=8080,
-                        help="Port to serve on")
+                        help="Port to serve on (tries next port if busy)")
     parser.add_argument("--host", default="0.0.0.0",
                         help="Host to bind to")
     parser.add_argument("--allow-delete", action="store_true",
                         help="Enable image deletion via UI (dangerous)")
     parser.add_argument("--sidecar", default=None,
                         help="CV sidecar URL for auto-detection (e.g. http://localhost:8001)")
+    parser.add_argument("--log-file", default=None,
+                        help="Path to log file (default: stderr)")
     args = parser.parse_args()
 
     IMAGE_DIR = os.path.abspath(args.dir)
     ALLOW_DELETE = args.allow_delete
     SIDECAR_URL = args.sidecar
 
+    # ── Logging setup ───────────────────────────────────────────────────────────
+    log_handler = logging.FileHandler(args.log_file) if args.log_file else logging.StreamHandler()
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(message)s",
+        handlers=[log_handler],
+    )
+    log = logging.getLogger("annotation")
+
     if not os.path.isdir(IMAGE_DIR):
-        print(f"ERROR: Directory not found: {IMAGE_DIR}")
+        log.error("Directory not found: %s", IMAGE_DIR)
         sys.exit(1)
 
     images = _get_image_list()
-    print(f"\n{'='*60}")
-    print(f"  WineBot Annotation Tool")
-    print(f"{'='*60}")
-    print(f"  Image directory: {IMAGE_DIR}")
-    print(f"  Images found:    {len(images)}")
-    print(f"  Classes:         {len(WINE_CLASSES)} (0-{len(WINE_CLASSES)-1})")
-    print(f"  Sidecar:         {SIDECAR_URL or 'not configured'}")
-    print(f"  Delete enabled:  {ALLOW_DELETE}")
-    print(f"  Server:          http://{args.host}:{args.port}")
-    print(f"{'='*60}")
-    print(f"\n  Keyboard shortcuts:")
-    print(f"    ← →         Previous/Next image")
-    print(f"    0-9         Select class")
-    print(f"    d / q       Draw / Select mode")
-    print(f"    Delete       Remove selected box")
-    print(f"    Ctrl+S       Save annotations")
-    print(f"    + / -         Zoom in/out")
-    if SIDECAR_URL:
-        print(f"    Space        Auto-detect with sidecar")
-    print(f"\n  Open http://localhost:{args.port} in your browser.\n")
+    log.info("Starting WineBot Annotation Tool")
+    log.info("Image directory: %s (%d images)", IMAGE_DIR, len(images))
+    log.info("Classes: %d (%s..%s)", len(WINE_CLASSES), WINE_CLASSES[0], WINE_CLASSES[-1])
+    log.info("Sidecar: %s", SIDECAR_URL or "not configured")
 
-    uvicorn.run(app, host=args.host, port=args.port, log_level="info")
+    # ── Port discovery with conflict fallback ───────────────────────────────────
+    import socket
+    port = args.port
+    max_attempts = 10
+    for attempt in range(max_attempts):
+        try:
+            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            sock.settimeout(1)
+            result = sock.connect_ex((args.host, port))
+            sock.close()
+            if result == 0:
+                log.warning("Port %d is in use, trying %d", port, port + 1)
+                port += 1
+            else:
+                break
+        except OSError:
+            port += 1
+    else:
+        log.error("Could not find free port after %d attempts (tried %d..%d)",
+                   max_attempts, args.port, port)
+        sys.exit(1)
+
+    log.info("Binding to %s:%d", args.host, port)
+
+    # ── Print banner to stdout (for interactive sessions) ────────────────────────
+    banner = (
+        f"\n{'='*60}\n"
+        f"  WineBot Annotation Tool\n"
+        f"{'='*60}\n"
+        f"  Image directory: {IMAGE_DIR}\n"
+        f"  Images found:    {len(images)}\n"
+        f"  Classes:         {len(WINE_CLASSES)} (0-{len(WINE_CLASSES)-1})\n"
+        f"  Sidecar:         {SIDECAR_URL or 'not configured'}\n"
+        f"  Delete enabled:  {ALLOW_DELETE}\n"
+        f"  Server:          http://{args.host}:{port}\n"
+        f"{'='*60}\n"
+        f"\n  Keyboard shortcuts:\n"
+        f"    {'Space':13s} Auto-detect with sidecar\n" if SIDECAR_URL else ""
+        f"    {'← →':13s} Previous/Next image\n"
+        f"    {'0-9':13s} Select class\n"
+        f"    d / q       Draw / Select mode\n"
+        f"    Delete       Remove selected box\n"
+        f"    Ctrl+S       Save annotations\n"
+        f"    + / -         Zoom in/out\n"
+        f"\n  Open http://localhost:{port} in your browser.\n"
+    )
+    print(banner)
+    log.info("Serving on %s:%d", args.host, port)
+
+    uvicorn.run(app, host=args.host, port=port, log_level="info",
+                access_log=False)
 
 
 if __name__ == "__main__":

--- a/scripts/start-annotation.sh
+++ b/scripts/start-annotation.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# ── Start Annotation Server ────────────────────────────────────────────────
+# Usage:
+#   scripts/start-annotation.sh                          # inside container
+#   MSYS_NO_PATHCONV=1 bash scripts/start-annotation.sh   # from Windows host
+#
+# When run from the host (Git Bash), MSYS_NO_PATHCONV=1 is required to
+# prevent Git Bash from translating container paths like /scripts to
+# Windows paths like C:/Program Files/Git/scripts.
+# ──────────────────────────────────────────────────────────────────────────────
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Source structured logging
+source "$SCRIPT_DIR/logging_utils.sh" 2>/dev/null || true
+
+# ── Config ─────────────────────────────────────────────────────────────────
+CONTAINER="${WB_CONTAINER:-winebot-cv}"
+ANNOTATION_DIR="${ANNOTATION_DIR:-/artifacts/annotations/images}"
+SERVER_PORT="${ANNOTATION_PORT:-8080}"
+SIDECAR_URL="${CV_SIDECAR_URL:-http://localhost:8001}"
+LOG_FILE="/tmp/annotation-server.log"
+
+log_start "Starting annotation server"
+
+# ── Check if running inside container ──────────────────────────────────────
+if [ -f /.dockerenv ] || [ -f /run/.containerenv ]; then
+    INSIDE_CONTAINER=1
+else
+    INSIDE_CONTAINER=0
+fi
+
+# ── Find annotation server script ──────────────────────────────────────────
+if [ "$INSIDE_CONTAINER" = "1" ]; then
+    SERVER_SCRIPT="/scripts/annotation_server.py"
+elif MSYS_NO_PATHCONV=1 docker exec "$CONTAINER" test -f /scripts/annotation_server.py 2>/dev/null; then
+    # Running from host — server lives inside container
+    :
+else
+    log_error "setup" "annotation_server.py not found in container $CONTAINER"
+    log_step "fix" "docker cp scripts/annotation_server.py $CONTAINER:/scripts/annotation_server.py"
+    exit 1
+fi
+
+# ── Ensure annotation directory exists with images ─────────────────────────
+if [ "$INSIDE_CONTAINER" = "1" ]; then
+    mkdir -p "$ANNOTATION_DIR"
+else
+    MSYS_NO_PATHCONV=1 docker exec "$CONTAINER" mkdir -p "$ANNOTATION_DIR" 2>/dev/null || true
+fi
+
+# ── Kill any previous annotation server ────────────────────────────────────
+log_step "cleanup" "Stopping any previous annotation server..."
+if [ "$INSIDE_CONTAINER" = "1" ]; then
+    pkill -f "annotation_server.py" 2>/dev/null || true
+    sleep 1
+else
+    MSYS_NO_PATHCONV=1 docker exec "$CONTAINER" sh -c \
+        "pkill -f annotation_server.py 2>/dev/null; sleep 1" 2>/dev/null || true
+fi
+
+# ── Start annotation server ────────────────────────────────────────────────
+# NOTE: On Windows (Git Bash), MSYS_NO_PATHCONV=1 is REQUIRED for all
+# docker commands that include Unix-style paths. Without it, Git Bash
+# translates /scripts → C:/Program Files/Git/scripts, causing "file not found".
+# See docs/debugging.md#git-bash-path-translation for details.
+log_step "start" "Starting annotation server on port $SERVER_PORT..."
+log_step "config" "Images: $ANNOTATION_DIR | Sidecar: $SIDECAR_URL | Log: $LOG_FILE"
+
+if [ "$INSIDE_CONTAINER" = "1" ]; then
+    # Direct launch inside container
+    nohup python3 /scripts/annotation_server.py \
+        --dir "$ANNOTATION_DIR" \
+        --port "$SERVER_PORT" \
+        --sidecar "$SIDECAR_URL" \
+        --log-file "$LOG_FILE" \
+        > /dev/null 2>&1 &
+    PID=$!
+else
+    # Remote launch via docker exec (note MSYS_NO_PATHCONV to prevent path mangling)
+    MSYS_NO_PATHCONV=1 docker exec -d "$CONTAINER" python3 /scripts/annotation_server.py \
+        --dir "$ANNOTATION_DIR" \
+        --port "$SERVER_PORT" \
+        --sidecar "$SIDECAR_URL" \
+        --log-file "$LOG_FILE"
+    PID="container-process"
+fi
+
+# ── Wait for server to respond ────────────────────────────────────────────
+sleep 2
+for i in $(seq 1 15); do
+    if [ "$INSIDE_CONTAINER" = "1" ]; then
+        if curl -sf "http://127.0.0.1:$SERVER_PORT/api/images" > /dev/null 2>&1; then
+            log_complete "Annotation server ready on http://127.0.0.1:$SERVER_PORT"
+            echo ""
+            echo "  Open http://localhost:$SERVER_PORT in your browser."
+            echo "  Logs: $LOG_FILE"
+            exit 0
+        fi
+    else
+        CONTAINER_IP=$(docker inspect "$CONTAINER" --format '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' 2>/dev/null)
+        if curl -sf "http://$CONTAINER_IP:$SERVER_PORT/api/images" > /dev/null 2>&1; then
+            log_complete "Annotation server ready on http://localhost:$SERVER_PORT"
+            echo ""
+            echo "  Open http://localhost:$SERVER_PORT in your browser."
+            echo "  Logs (in container): $LOG_FILE"
+            exit 0
+        fi
+    fi
+    sleep 1
+done
+
+log_error "startup" "Annotation server did not become ready within 15s"
+log_step "diagnose" "docker exec $CONTAINER cat $LOG_FILE"
+exit 1


### PR DESCRIPTION
## Summary

Diagnosed and fixed all issues encountered during annotation server setup:

1. **Port conflict** — server now probes for available ports (falls back to port+1) instead of crashing
2. **No startup logging** — added logging via `--log-file` arg with level-based output
3. **No startup script** — created `scripts/start-annotation.sh` that handles MSYS path mangling, clean shutdown, and health checks
4. **Git Bash path mangling** — documented in `docs/debugging.md` with prevention steps for all affected docker commands
5. **Graceful cleanup** — startup script auto-kills previous annotation server instance

## Files Changed

| File | Change |
|:---|:---|
| `scripts/annotation_server.py` | Added logging, port conflict fallback, --log-file arg |
| `scripts/start-annotation.sh` | NEW — startup script with MSYS handling, health checks |
| `docs/debugging.md` | Added Git Bash Path Translation section |

## Verification

- [x] Server starts cleanly on first attempt
- [x] Server falls back to port+1 if port is taken
- [x] Startup script works from host (with MSYS_NO_PATHCONV=1)
- [x] Startup script works inside container
- [x] Logs are written to specified log file
- [x] Git Bash docs cover docker cp, exec, run -v, and -d cases

Closes #75