### PR TITLE
Fix stateless container architecture — HF cache, captioning sidecar

### DIFF
--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -184,12 +184,14 @@ services:
       - ../artifacts:/artifacts:ro
       # Mount demo output for batch CV analysis
       - ../demo/output:/demo-output:ro
-      # Host model cache (persists YOLO weights across container rebuilds)
+      # Host YOLO model weights (pre-downloaded, read-only)
       - ../models/yolo:/models:ro
       # Host tessdata cache (persists Tesseract language data)
       - ../models/tessdata:/usr/share/tesseract-ocr/5/tessdata:ro
       # Host annotation cache (persists labels across container recreations)
       - ../models/annotations:/artifacts/annotations
+      # HuggingFace model cache (writable — runtime downloads for CLIP, Florence-2, etc.)
+      - ../models/huggingface:/root/.cache/huggingface
     environment:
       YOLO_MODEL_PATH: /models/yolov8n.pt
     healthcheck:
@@ -199,6 +201,38 @@ services:
       retries: 5
       start_period: 15s
     command: ["--serve", "--host", "0.0.0.0", "--port", "8001"]
+
+  # ── Captioning Sidecar (optional, built from docker/captioning-sidecar/Dockerfile) ──
+  winebot-captioner:
+    build:
+      context: ../docker/captioning-sidecar
+      dockerfile: Dockerfile
+    image: winebot-captioner:${WINEBOT_IMAGE_VERSION:-local}
+    profiles:
+      - interactive
+      - test
+    ports:
+      - "8002:8002"
+    volumes:
+      # HuggingFace model cache (persists Florence-2 weights across rebuilds)
+      - ../models/huggingface:/root/.cache/huggingface
+    environment:
+      CAPTIONER_MODEL: ${CAPTIONER_MODEL:-microsoft/Florence-2-base}
+      CAPTIONER_LORA_PATH: ${CAPTIONER_LORA_PATH:-}
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: 1
+              capabilities: [gpu]
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://localhost:8002/health || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+    command: ["--serve", "--host", "0.0.0.0", "--port", "8002"]
 
 volumes:
   wineprefix:


### PR DESCRIPTION
## Summary

Ensures all containers are truly disposable by auditing and fixing volume mounts.

## Changes

1. Added HuggingFace model cache volume to CV sidecar (`../models/huggingface:/root/.cache/huggingface`)
2. Added captioning sidecar service to docker-compose.yml with proper GPU reservations
3. Created model cache directories with .gitkeep files
4. All state verified on volumes — no data lost on container recreation

## Volume Map

| Container Path | Host/Volume | Purpose | Writable? |
|:---|---|:---|:---:|
| `/wineprefix` | `wineprefix` (named volume) | Wine prefix state | ✅ |
| `/artifacts` | `../artifacts` | Sessions, logs, recordings | ✅ |
| `/winebot-shared` | `winebot-shared` (named) | API token sharing | ✅ |
| `/models` | `../models/yolo` | YOLO weights | ❌ ro |
| `/usr/share/tesseract-ocr/5/tessdata` | `../models/tessdata` | OCR language data | ❌ ro |
| `/artifacts/annotations` | `../models/annotations` | Bounding box labels | ✅ |
| `/root/.cache/huggingface` | `../models/huggingface` | Runtime model downloads | ✅ |

Closes #80