### PR TITLE
licensing: transition from MIT to PolyForm Noncommercial 1.0.0

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,22 +1,75 @@
-MIT License
+# PolyForm Noncommercial License 1.0.0
 
-Copyright (c) 2026 WineBot contributors
+<https://polyformproject.org/licenses/noncommercial/1.0.0>
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+## Acceptance
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+In order to get any license under these terms, you must agree to them as both strict obligations and conditions to all your licenses.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+## Copyright License
 
+The licensor grants you a copyright license for the software to do everything you might do with the software that would otherwise infringe the licensor's copyright in it for any permitted purpose.  However, you may only distribute the software according to [Distribution License](#distribution-license) and make changes or new works based on the software according to [Changes and New Works License](#changes-and-new-works-license).
+
+## Distribution License
+
+The licensor grants you an additional copyright license to distribute copies of the software.  Your license to distribute covers distributing the software with changes and new works permitted by [Changes and New Works License](#changes-and-new-works-license).
+
+## Notices
+
+You must ensure that anyone who gets a copy of any part of the software from you also gets a copy of these terms or the URL for them above, as well as copies of any plain-text lines beginning with `Required Notice:` that the licensor provided with the software.  For example:
+
+> Required Notice: Copyright Yoyodyne, Inc. (http://example.com)
+
+## Changes and New Works License
+
+The licensor grants you an additional copyright license to make changes and new works based on the software for any permitted purpose.
+
+## Patent License
+
+The licensor grants you a patent license for the software that covers patent claims the licensor can license, or becomes able to license, that you would infringe by using the software.
+
+## Noncommercial Purposes
+
+Any noncommercial purpose is a permitted purpose.
+
+## Personal Uses
+
+Personal use for research, experiment, and testing for the benefit of public knowledge, personal study, private entertainment, hobby projects, amateur pursuits, or religious observance, without any anticipated commercial application, is use for a permitted purpose.
+
+## Noncommercial Organizations
+
+Use by any charitable organization, educational institution, public research organization, public safety or health organization, environmental protection organization, or government institution is use for a permitted purpose regardless of the source of funding or obligations resulting from the funding.
+
+## Fair Use
+
+You may have "fair use" rights for the software under the law. These terms do not limit them.
+
+## No Other Rights
+
+These terms do not allow you to sublicense or transfer any of your licenses to anyone else, or prevent the licensor from granting licenses to anyone else.  These terms do not imply any other licenses.
+
+## Patent Defense
+
+If you make any written claim that the software infringes or contributes to infringement of any patent, your patent license for the software granted under these terms ends immediately. If your company makes such a claim, your patent license ends immediately for work on behalf of your company.
+
+## Violations
+
+The first time you are notified in writing that you have violated any of these terms, or done anything with the software not covered by your licenses, your licenses can nonetheless continue if you come into full compliance with these terms, and take practical steps to correct past violations, within 32 days of receiving notice.  Otherwise, all your licenses end immediately.
+
+## No Liability
+
+***As far as the law allows, the software comes as is, without any warranty or condition, and the licensor will not be liable to you for any damages arising out of these terms or the use or nature of the software, under any kind of legal claim.***
+
+## Definitions
+
+The **licensor** is the individual or entity offering these terms, and the **software** is the software the licensor makes available under these terms.
+
+**You** refers to the individual or entity agreeing to these terms.
+
+**Your company** is any legal entity, sole proprietorship, or other kind of organization that you work for, plus all organizations that have control over, are under the control of, or are under common control with that organization.  **Control** means ownership of substantially all the assets of an entity, or the power to direct its management and policies by vote, contract, or otherwise.  Control can be direct or indirect.
+
+**Your licenses** are all the licenses granted to you for the software under these terms.
+
+**Use** means anything you do with the software requiring one of your licenses.
+
+Copyright (c) 2026 Mark E. DeYoung.

--- a/LICENSE.commercial
+++ b/LICENSE.commercial
@@ -1,0 +1,43 @@
+# WineBot — Commercial License
+
+This commercial license is required for any commercial use of WineBot by any
+**organization, company, government entity, or any legal entity** (not an
+individual natural person). Individuals may use WineBot for any purpose under
+the PolyForm Noncommercial License + Additional Permission.
+
+## Scope
+
+A commercial license grants you the right to:
+
+1. **Use** WineBot for any internal commercial purpose
+2. **Install and operate** WineBot in production environments
+3. **Modify** WineBot for your internal needs
+4. **Integrate** WineBot into your products and services
+5. **Receive support** and maintenance updates
+
+## What Is Not Covered
+
+- Redistribution or sublicensing of WineBot to third parties
+- Creating competing products based on WineBot
+- Transferring licenses between organizations
+
+## Pricing
+
+Contact the licensor for current pricing. Tiers available:
+
+| Tier | Use Case |
+|:-----|:---------|
+| **Single Project** | One application or internal tool |
+| **Enterprise** | Unlimited internal use across the organization |
+| **OEM/Embedded** | Integration into distributed products |
+
+## Contact
+
+Mark E. DeYoung
+Email: [contact email]
+Project: https://github.com/SemperSupra/WineBot
+
+---
+
+*This document is a summary of commercial licensing terms. A formal license
+agreement will be provided upon request. Terms are negotiable.*

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,67 @@
+WineBot
+Copyright (c) 2026 Mark E. DeYoung.
+Licensed under PolyForm Noncommercial 1.0.0 with Additional Permission.
+
+========================================================================
+Third-Party Notices
+========================================================================
+
+This project incorporates or depends on components from the following
+projects. Each component has its own license and copyright.
+
+========================================================================
+websockify (LGPLv3)
+========================================================================
+websockify is used as a standalone subprocess (not linked) to provide
+the VNC-to-WebSocket proxy.
+
+Copyright (C) 2011 OpenStack Foundation
+Copyright (C) 2010 Joel Martin
+License: GNU Lesser General Public License v3.0 (LGPLv3)
+Source: https://github.com/novnc/websockify
+
+========================================================================
+Wine (LGPLv2.1+)
+========================================================================
+Wine provides the Windows compatibility layer. It is a standalone
+system-level dependency within the Docker image.
+
+Copyright (C) 2003-2024 Wine contributors
+License: GNU Lesser General Public License v2.1 or later
+Source: https://www.winehq.org/
+
+========================================================================
+AutoHotkey (GPLv2+)
+========================================================================
+AutoHotkey is bundled as a standalone binary for Windows automation.
+
+Copyright (C) 2004-2024 AutoHotkey contributors
+License: GNU General Public License v2.0 or later
+Source: https://www.autohotkey.com/
+
+========================================================================
+AutoIt (Freeware)
+========================================================================
+AutoIt is bundled as a standalone binary for Windows automation.
+
+Copyright (C) 1999-2024 AutoIt Consulting Ltd.
+License: AutoIt End-User License Agreement (freeware)
+Source: https://www.autoitscript.com/
+
+========================================================================
+WinInspect (MIT)
+========================================================================
+WinInspect provides Windows UI inspection capabilities.
+
+Copyright (C) 2024 SemperSupra
+License: MIT
+Source: https://github.com/SemperSupra/WinInspect
+
+========================================================================
+Python Embedded (Python Software Foundation License)
+========================================================================
+A minimal embedded Python distribution for running automation scripts.
+
+Copyright (C) 2001-2024 Python Software Foundation
+License: Python Software Foundation License (PSF)
+Source: https://www.python.org/

--- a/README.md
+++ b/README.md
@@ -452,3 +452,14 @@ Use the `Base Image` workflow to publish versioned base images:
 - `docs/installing-apps.md`
 - `docs/testing.md`
 - `docs/troubleshooting.md`
+
+## License
+
+**PolyForm Noncommercial 1.0.0**
+
+- **Non-commercial use** — Free for everyone (education, research, personal, hobby, government).
+- **Commercial use** — ANY commercial use by ANY person or organization requires a [commercial license](LICENSE.commercial).
+
+See [LICENSE](LICENSE) for the full license terms and [NOTICE](NOTICE) for third-party attributions.
+
+Commercial license inquiries: [contact information]


### PR DESCRIPTION
Closes #102

## Summary

Replace MIT license with **PolyForm Noncommercial 1.0.0** to match the project's dual-purpose goals (open source auditability + commercial licensing for income).

### Files

| File | Purpose |
|:-----|:--------|
| LICENSE | PolyForm Noncommercial 1.0.0 — any commercial use requires a license |
| LICENSE.commercial | Commercial license template for inquiries |
| NOTICE | Third-party attributions (websockify LGPLv3, Wine LGPL, AHK, AutoIt, WinInspect, Python) |
| README.md | Added licensing section with clear terms |

### Key Provisions

- **Non-commercial use**: Free for everyone (education, research, personal, hobby, government)
- **Commercial use**: ANY commercial use by ANY person or organization requires a license
- **No Liability**: '"As is", without warranty, licensor not liable for any damages'
- **Patent Defense**: License terminates if user sues for patent infringement
- **32-day cure period**: Inadvertent violations can be corrected

### Related

- desktop-ui-cv: #15 (same license transition)
- Maintenance: MIT license (infrastructure repo)
- Issues for tracked items: #103 (website), #104 (SPDX headers), #105 (legal review), #106 (CLA)

### Decision Rationale

PolyForm Noncommercial was chosen over alternatives:
- **MIT** (previous): allows anyone to use/sell commercially for free ❌
- **PolyForm Shield**: only blocks competing products, not internal commercial use ❌
- **AGPLv3**: strong copyleft, but network clause creates compliance burden for commercial users ❌
- **BSL 1.1**: converts to open source after time period, not ideal for permanent licensing ❌
- **PolyForm Noncommercial**: clean separation between non-commercial (free) and commercial (licensed) ✅