### PR TITLE
licensing: override government exemption — government must pay

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -73,3 +73,12 @@ The **licensor** is the individual or entity offering these terms, and the **sof
 **Use** means anything you do with the software requiring one of your licenses.
 
 Copyright (c) 2026 Mark E. DeYoung.
+
+## Additional Terms — Government Use
+
+Notwithstanding the "Noncommercial Organizations" section above, use of the
+software by any government institution or any entity owned, controlled, or
+chartered by a government (including but not limited to federal, state, local,
+municipal, and international governmental bodies) is NOT a permitted purpose
+under this license. Government institutions require a commercial license for
+any use of the software.

--- a/README.md
+++ b/README.md
@@ -455,10 +455,11 @@ Use the `Base Image` workflow to publish versioned base images:
 
 ## License
 
-**PolyForm Noncommercial 1.0.0**
+**PolyForm Noncommercial 1.0.0** with Additional Terms for Government Use.
 
-- **Non-commercial use** — Free for everyone (education, research, personal, hobby, government).
+- **Non-commercial use** — Free for everyone (education, research, personal, hobby, charitable, non-profit).
 - **Commercial use** — ANY commercial use by ANY person or organization requires a [commercial license](LICENSE.commercial).
+- **Government use** — Requires a [commercial license](LICENSE.commercial). Government is NOT exempt under this license.
 
 See [LICENSE](LICENSE) for the full license terms and [NOTICE](NOTICE) for third-party attributions.
 


### PR DESCRIPTION
Overrides the PolyForm Noncommercial default exemption for government institutions.\n\nStandard PolyForm Noncommercial 1.0.0 lists government as a noncommercial (free) use. This override requires government institutions to purchase a commercial license.\n\nCloses #102.