### PR TITLE
feat: create commercial licensing page and contact info

### DIFF
--- a/LICENSE.commercial
+++ b/LICENSE.commercial
@@ -34,8 +34,10 @@ Contact the licensor for current pricing. Tiers available:
 ## Contact
 
 Mark E. DeYoung
-Email: [contact email]
+Email: mark.e.deyoung@gmail.com
+Subject: "WineBot Commercial License"
 Project: https://github.com/SemperSupra/WineBot
+Licensing info: https://github.com/SemperSupra/WineBot/blob/main/docs/licensing.md
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -463,4 +463,4 @@ Use the `Base Image` workflow to publish versioned base images:
 
 See [LICENSE](LICENSE) for the full license terms and [NOTICE](NOTICE) for third-party attributions.
 
-Commercial license inquiries: [contact information]
+**Commercial license inquiries:** See [docs/licensing.md](docs/licensing.md) or email `mark.e.deyoung@gmail.com` with subject "WineBot Commercial License".

--- a/docs/licensing.md
+++ b/docs/licensing.md
@@ -1,0 +1,43 @@
+# WineBot Commercial Licensing
+
+**PolyForm Noncommercial 1.0.0** applies to all source code in this repository
+with an override for government use. See [LICENSE](../LICENSE) for full terms.
+
+## Who Needs a Commercial License?
+
+| Entity Type | Commercial Use? | Needs License? |
+|:------------|:----------------|:--------------|
+| Individual (any purpose) | ✅ Yes | ✅ **Yes** |
+| Organization (any commercial use) | ✅ Yes | ✅ **Yes** |
+| Government (any level, any purpose) | ✅ Yes | ✅ **Yes** |
+| Non-commercial (education, research, personal, hobby, charity) | ❌ No | ❌ **Free** |
+
+## What a Commercial License Covers
+
+- Use WineBot for any internal commercial purpose
+- Install and operate WineBot in production
+- Modify WineBot for your internal needs
+- Integrate WineBot into your products and services
+- Receive support and maintenance updates
+
+## Pricing Tiers
+
+| Tier | Use Case |
+|:-----|:---------|
+| **Individual** | Solo practitioner or freelancer |
+| **Startup** | Companies under 10 employees |
+| **Enterprise** | Unlimited internal use across the organization |
+| **Government** | Federal, state, local, international agencies |
+| **OEM/Embedded** | Integration into distributed products |
+
+## Contact
+
+For commercial license pricing and inquiries, please contact:
+
+**Mark E. DeYoung**  
+Email: `mark.e.deyoung@gmail.com`  
+Subject: "WineBot Commercial License"
+
+## License Agreement
+
+A formal license agreement will be provided upon request. Terms are negotiable.


### PR DESCRIPTION
Closes #103\n\n- docs/licensing.md: pricing tiers, contact info, who-needs-what table\n- README.md: link to licensing page with contact email\n- LICENSE.commercial: add contact email and page URL