### PR TITLE
feat: add winebot-contracts submodule for shared conformance tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,3 +59,110 @@ jobs:
       generate_trust_pack: true
       trust_pack_dir: artifacts/trust-pack
       trust_pack_artifact_name: trust-pack-ci
+
+  conformance:
+    name: 🔬 Conformance (winebot-contracts)
+    needs: [pre-flight, integration]
+    if: |
+      always() &&
+      !cancelled() &&
+      (github.event_name == 'workflow_dispatch' ||
+       github.ref_name == 'main' ||
+       startsWith(github.ref_name, 'release/'))
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          submodules: recursive
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install conformance test deps
+        run: |
+          pip install -r contracts/tests/conformance/requirements.txt
+
+      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
+
+      - name: Build WineBot image
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f
+        with:
+          context: .
+          file: docker/Dockerfile
+          target: intent-slim
+          build-args: |
+            BASE_IMAGE=${{ vars.WINEBOT_BASE_IMAGE || 'ghcr.io/sempersupra/winebot-base:base-2026-05-04' }}
+            BUILD_INTENT=slim
+            VCS_REF=${{ github.sha }}
+            SOURCE_REPO=https://github.com/${{ github.repository }}
+          load: true
+          push: false
+          tags: winebot:conformance-test
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Start WineBot container
+        id: start-winebot
+        run: |
+          API_TOKEN=$(openssl rand -hex 32)
+          echo "api-token=$API_TOKEN" >> $GITHUB_OUTPUT
+          export API_TOKEN=$API_TOKEN
+          docker compose -f compose/docker-compose.yml --profile interactive up -d winebot
+          # Wait for the API to be ready
+          echo "Waiting for WineBot API to be ready..."
+          for i in $(seq 1 30); do
+            if curl -s -o /dev/null -w "%{http_code}" -H "X-API-Key: $API_TOKEN" http://localhost:8000/health 2>/dev/null | grep -q 200; then
+              echo "API ready after ${i}s"
+              break
+            fi
+            sleep 2
+          done
+
+      - name: Run shared conformance tests
+        id: conformance
+        continue-on-error: false
+        env:
+          API_URL: http://localhost:8000
+          API_TOKEN: ${{ steps.start-winebot.outputs.api-token }}
+          CONFORMANCE_RESULTS_DIR: conformance-results
+        run: |
+          mkdir -p "$CONFORMANCE_RESULTS_DIR"
+          python -m pytest contracts/tests/conformance/ \
+            --api-url "http://localhost:8000" \
+            --api-token "${{ steps.start-winebot.outputs.api-token }}" \
+            --results-file "$CONFORMANCE_RESULTS_DIR/winebot-$(date -u +%Y%m%d-%H%M%S).json" \
+            -v --tb=short \
+            --junit-xml="$CONFORMANCE_RESULTS_DIR/junit-winebot.xml"
+
+      - name: Upload conformance results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: conformance-results-winebot-${{ github.run_id }}
+          path: conformance-results/
+
+      - name: Conformance release gate
+        if: |
+          success() &&
+          (github.ref_name == 'main' || startsWith(github.ref_name, 'release/'))
+        run: |
+          RESULTS=$(ls conformance-results/winebot-*.json 2>/dev/null | head -1)
+          if [ -z "$RESULTS" ]; then
+            echo "No conformance results found — skipping gate"
+            exit 0
+          fi
+          FAILED=$(python3 -c "import json; d=json.load(open('$RESULTS')); print(d['summary']['failed'])")
+          TOTAL=$(python3 -c "import json; d=json.load(open('$RESULTS')); print(d['summary']['total'])")
+          RATE=$(python3 -c "import json; d=json.load(open('$RESULTS')); print(d['summary']['pass_rate'])")
+          echo "Conformance: $TOTAL tests, $RATE% pass rate"
+          if [ "$FAILED" -gt 0 ]; then
+            echo "❌ Conformance FAILED — release gate blocked"
+            python3 -c "import json; d=json.load(open('$RESULTS')); [print(f'  FAIL: {f[\"test\"]} — {f[\"message\"]}') for f in d['failures']]"
+            exit 1
+          fi
+          echo "✅ Conformance PASSED — release gate cleared"
+
+      - name: Cleanup
+        if: always()
+        run: docker compose -f compose/docker-compose.yml down -v 2>/dev/null || true

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "contracts"]
+	path = contracts
+	url = https://github.com/mark-e-deyoung/winebot-contracts.git


### PR DESCRIPTION
@
## Summary

Add the centralized [winebot-contracts](https://github.com/mark-e-deyoung/winebot-contracts) repository as a git submodule and wire it into CI as a conformance release gate.

This is part of a coordinated effort across WineBot and WinBot to centralize all shared parity and conformance testing into a single source of truth. The WinBot equivalent PR is mark-e-deyoung/WinBot#68.

## Changes

1. **Git submodule** at `contracts/` → `mark-e-deyoung/winebot-contracts`
   - Contains the shared pytest-based conformance test suite
   - Shared OpenAPI spec, CLI contract, session schemas, MCP tools
   - All 14 test modules cover: health, lifecycle, input, automation, recording, tracing, idempotency, version, errors, headers

2. **CI job** (`conformance`) in `.github/workflows/ci.yml`
   - Runs after pre-flight and integration smoke tests
   - Builds WineBot Docker image, starts container, runs the shared conformance tests
   - Generates structured JSON results for the historical conformance dashboard
   - Uploads results as CI artifacts

3. **Release gate**: conformance tests must pass on `main` and `release/` branches — failing conformance blocks the pipeline

## Why

Both WineBot and WinBot implement the same API contract. Previously each had its own separate parity tests that drifted independently. Now:
- The contract is defined once in `winebot-contracts`
- Both projects run the **same** tests from the **same** source
- Conformance history is tracked over time via dashboard at https://mark-e-deyoung.github.io/winebot-contracts/
- Passing conformance is required before releases

## Related

- winebot-contracts PR [#2](https://github.com/mark-e-deyoung/winebot-contracts/pull/2): Centralize conformance tests
- WinBot PR [#68](https://github.com/mark-e-deyoung/WinBot/pull/68): Parallel changes on WinBot side
- Issue [#1](https://github.com/mark-e-deyoung/winebot-contracts/issues/1): Meta-issue tracking this work

## Verification

- [x] Submodule clones correctly: `git submodule update --init`
- [x] Conformance tests install: `pip install -r contracts/tests/conformance/requirements.txt`
- [x] Tests run standalone: `pytest contracts/tests/conformance/ --api-url URL --api-token TOKEN`
- [x] Results tracking generates structured JSON
