### PR TITLE
feat: add window.listChildren, update protocol version to 0.4.0

### DIFF
--- a/api/core/wininspect.py
+++ b/api/core/wininspect.py
@@ -26,6 +26,7 @@ READ_ONLY_METHODS = {
     "window.listChildren",
     "window.getInfo",
     "window.getTree",
+    "window.getZOrder",
     "window.pickAtPoint",
     "window.findRegex",
     "screen.desktopInfo",
@@ -265,7 +266,7 @@ def request(method: str, params: dict[str, Any] | None = None) -> dict[str, Any]
         "id": request_id,
         "method": method,
         "params": {
-            "protocol_version": "0.3.0",
+            "protocol_version": "0.4.0",
             **(params or {}),
         },
     }
@@ -336,3 +337,9 @@ def find_windows(
 def pick_at_point(x: int, y: int) -> dict[str, Any]:
     result = request("window.pickAtPoint", {"x": x, "y": y})["result"]
     return result if isinstance(result, dict) else {"raw": result}
+
+
+def list_children(hwnd: str) -> list[dict[str, Any]]:
+    """List child windows of an HWND through WinInspect."""
+    result = request("window.listChildren", {"hwnd": hwnd})["result"]
+    return result if isinstance(result, list) else []

--- a/api/routers/automation.py
+++ b/api/routers/automation.py
@@ -214,6 +214,17 @@ async def wininspect_window(hwnd: str, include_tree: bool = False):
         raise _wininspect_error(exc)
 
 
+@router.get("/wininspect/window/{hwnd}/children")
+async def wininspect_children(hwnd: str):
+    """List child windows of an HWND through WinInspect."""
+    _wininspect_or_503()
+    try:
+        children = wininspect.list_children(hwnd)
+        return {"ok": True, "children": children, "count": len(children)}
+    except Exception as exc:
+        raise _wininspect_error(exc)
+
+
 @router.get("/wininspect/screen")
 async def wininspect_screen():
     """Return WinInspect desktop geometry and DPI information."""


### PR DESCRIPTION
## Summary

Three changes for WinInspect v0.4.0 integration:

1. **Protocol version**: Updated from 0.3.0 to 0.4.0
2. **window.listChildren**: New endpoint GET /wininspect/window/{hwnd}/children for recursive UIA tree traversal
3. **window.getZOrder**: Added to READ_ONLY_METHODS

## Endpoints

| Method | Path | Description |
|---|---|---|
| GET | /wininspect/window/{hwnd}/children | List child windows of an HWND |

Part of Package C (WineBot Read Expansion).

Closes #117