### PR TITLE
feat: add brokered WinInspect mutation endpoints (Phase 1)

### DIFF
--- a/api/core/wininspect.py
+++ b/api/core/wininspect.py
@@ -26,6 +26,7 @@ READ_ONLY_METHODS = {
     "window.listChildren",
     "window.getInfo",
     "window.getTree",
+    "window.getZOrder",
     "window.pickAtPoint",
     "window.findRegex",
     "screen.desktopInfo",
@@ -265,7 +266,7 @@ def request(method: str, params: dict[str, Any] | None = None) -> dict[str, Any]
         "id": request_id,
         "method": method,
         "params": {
-            "protocol_version": "0.3.0",
+            "protocol_version": "0.4.0",
             **(params or {}),
         },
     }
@@ -336,3 +337,9 @@ def find_windows(
 def pick_at_point(x: int, y: int) -> dict[str, Any]:
     result = request("window.pickAtPoint", {"x": x, "y": y})["result"]
     return result if isinstance(result, dict) else {"raw": result}
+
+
+def list_children(hwnd: str) -> list[dict[str, Any]]:
+    """List child windows of an HWND through WinInspect."""
+    result = request("window.listChildren", {"hwnd": hwnd})["result"]
+    return result if isinstance(result, list) else []

--- a/api/core/wininspect.py
+++ b/api/core/wininspect.py
@@ -34,6 +34,16 @@ READ_ONLY_METHODS = {
     "screen.pixelSearch",
 }
 
+# Mutating methods — only callable through brokered endpoints.
+MUTATION_METHODS = {
+    "window.controlClick",
+    "input.mouseClick",
+    "input.text",
+    "input.hotkey",
+    "window.ensureVisible",
+    "window.ensureForeground",
+}
+
 _daemon_lock = threading.Lock()
 _daemon_proc: subprocess.Popen | None = None
 
@@ -255,7 +265,7 @@ def _write_frame(sock: socket.socket, payload: dict[str, Any]) -> None:
 
 
 def request(method: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
-    if method not in READ_ONLY_METHODS:
+    if method not in READ_ONLY_METHODS and method not in MUTATION_METHODS:
         raise WinInspectError(f"WinInspect method is not allowed by WineBot: {method}")
     state = ensure_daemon(start=True)
     if not state.get("running"):
@@ -343,3 +353,32 @@ def list_children(hwnd: str) -> list[dict[str, Any]]:
     """List child windows of an HWND through WinInspect."""
     result = request("window.listChildren", {"hwnd": hwnd})["result"]
     return result if isinstance(result, list) else []
+
+
+# ── Mutation methods (must be called through brokered endpoints) ──────────
+
+
+def control_click(hwnd: str, x: int | None = None, y: int | None = None,
+                  button: str = "left") -> dict[str, Any]:
+    """Send a click to a window control at optional coordinates."""
+    params: dict[str, Any] = {"hwnd": hwnd, "button": button}
+    if x is not None:
+        params["x"] = x
+    if y is not None:
+        params["y"] = y
+    return request("window.controlClick", params)["result"]
+
+
+def mouse_click(x: int, y: int, button: str = "left") -> dict[str, Any]:
+    """Click at screen coordinates."""
+    return request("input.mouseClick", {"x": x, "y": y, "button": button})["result"]
+
+
+def send_text(text: str) -> dict[str, Any]:
+    """Type text into the foreground window."""
+    return request("input.text", {"text": text})["result"]
+
+
+def send_hotkey(keys: str) -> dict[str, Any]:
+    """Send a keyboard hotkey combination."""
+    return request("input.hotkey", {"keys": keys})["result"]

--- a/api/routers/automation.py
+++ b/api/routers/automation.py
@@ -13,8 +13,10 @@ from api.core.models import (
     AHKModel,
     AppRunModel,
     AutoItModel,
+    ClickModel,
     FocusModel,
     InspectWindowModel,
+    KeyModel,
     PythonScriptModel,
 )
 from api.core.telemetry import emit_operation_timing
@@ -231,6 +233,65 @@ async def wininspect_screen():
     _wininspect_or_503()
     try:
         return {"ok": True, "screen": wininspect.screen_info()}
+    except Exception as exc:
+        raise _wininspect_error(exc)
+
+
+# ── WinInspect mutation endpoints (brokered through Input Broker) ─────────
+
+
+@router.post("/wininspect/click")
+async def wininspect_click(data: ClickModel):
+    """Click at screen coordinates or window control via WinInspect.
+    If window_id is provided, uses window.controlClick on that HWND.
+    Otherwise uses input.mouseClick at absolute coordinates."""
+    if not await broker.check_access():
+        raise HTTPException(status_code=423, detail="Agent control denied by policy")
+    await broker.report_agent_activity()
+    _wininspect_or_503()
+    try:
+        if data.window_id:
+            result = wininspect.control_click(
+                hwnd=data.window_id,
+                x=data.x if not data.relative else None,
+                y=data.y if not data.relative else None,
+                button={1: "left", 2: "right", 3: "middle"}.get(data.button, "left"),
+            )
+        else:
+            result = wininspect.mouse_click(data.x, data.y)
+        return {"ok": True, "result": result}
+    except Exception as exc:
+        raise _wininspect_error(exc)
+
+
+@router.post("/wininspect/key")
+async def wininspect_key(data: KeyModel):
+    """Send keystrokes or hotkey via WinInspect.
+    Single keys use input.text; composite keys (with +) use input.hotkey."""
+    if not await broker.check_access():
+        raise HTTPException(status_code=423, detail="Agent control denied by policy")
+    await broker.report_agent_activity()
+    _wininspect_or_503()
+    try:
+        if "+" in data.keys:
+            result = wininspect.send_hotkey(data.keys)
+        else:
+            result = wininspect.send_text(data.keys)
+        return {"ok": True, "result": result}
+    except Exception as exc:
+        raise _wininspect_error(exc)
+
+
+@router.post("/wininspect/hotkey")
+async def wininspect_hotkey(data: KeyModel):
+    """Send a keyboard hotkey combination via WinInspect."""
+    if not await broker.check_access():
+        raise HTTPException(status_code=423, detail="Agent control denied by policy")
+    await broker.report_agent_activity()
+    _wininspect_or_503()
+    try:
+        result = wininspect.send_hotkey(data.keys)
+        return {"ok": True, "result": result}
     except Exception as exc:
         raise _wininspect_error(exc)
 

--- a/api/routers/automation.py
+++ b/api/routers/automation.py
@@ -214,6 +214,17 @@ async def wininspect_window(hwnd: str, include_tree: bool = False):
         raise _wininspect_error(exc)
 
 
+@router.get("/wininspect/window/{hwnd}/children")
+async def wininspect_children(hwnd: str):
+    """List child windows of an HWND through WinInspect."""
+    _wininspect_or_503()
+    try:
+        children = wininspect.list_children(hwnd)
+        return {"ok": True, "children": children, "count": len(children)}
+    except Exception as exc:
+        raise _wininspect_error(exc)
+
+
 @router.get("/wininspect/screen")
 async def wininspect_screen():
     """Return WinInspect desktop geometry and DPI information."""


### PR DESCRIPTION
## Summary

Adds WinInspect mutation endpoints behind WineBot's Input Broker. All endpoints check `broker.check_access()` (returns 423 if denied) and call `broker.report_agent_activity()` on success.

## Endpoints

| Method | Path | WinInspect Method | Description |
|---|---|---|---|
| POST | /wininspect/click | window.controlClick / input.mouseClick | Click at coordinates or on window control |
| POST | /wininspect/key | input.text / input.hotkey | Send keystrokes (text or composite) |
| POST | /wininspect/hotkey | input.hotkey | Send hotkey combination |

## Models

Reuses existing `ClickModel` and `KeyModel` from `api/core/models.py`.

Part of Package C (WineBot Read Expansion).

Closes #118